### PR TITLE
#39 Resolve deprecation warnings by using snprintf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ testBuildGLEW_multifile.cpp
 testBuildGLAD_multifile.cpp
 tests/
 bin/*
+compile_commands.json

--- a/ShaderUtils.hpp
+++ b/ShaderUtils.hpp
@@ -438,7 +438,7 @@ inline void CSCI441_INTERNAL::ShaderUtils::printShaderProgramInfo(
     int max_attr_name_size;
     int max_uniform_name_size;
 
-    // get max var name for driver
+    // get max var name from program
     // https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetActiveAttrib.xhtml
     glGetProgramiv(programHandle, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &max_attr_name_size);
     glGetProgramiv(programHandle, GL_ACTIVE_UNIFORM_MAX_LENGTH, &max_uniform_name_size);


### PR DESCRIPTION
- Use dynamically sized name
- Size is retrieved from the driver for the longest var name in program

Dynamically allocating is less clean / slower, but as this is only used for logging purposes as startup, I don't think it is significant, especially as memory is freed after it has been written.

Currently not checking to make sure that `snprintf` succeeded (or any calls for that matter), but that can be added if deemed necessary.
